### PR TITLE
Enable Salsa-CI (Closes: #1)

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -1,0 +1,20 @@
+---
+include:
+  - https://salsa.debian.org/salsa-ci-team/pipeline/raw/master/salsa-ci.yml
+  - https://salsa.debian.org/salsa-ci-team/pipeline/raw/master/pipeline-jobs.yml
+
+# Disable failing reprotest. If needs more investigation and fixing before it
+# can be enabled.
+variables:
+  SALSA_CI_DISABLE_REPROTEST: 1
+
+# BLHC currently fails on two issues. Make the CI job result visible, but do not
+# fail on it.
+blhc:
+  extends: .test-blhc
+  allow_failure: true
+
+# If Salsa-CI is not running at
+# https://salsa.debian.org/%{project_path}/-/pipelines, ensure that
+# https://salsa.debian.org/%{project_path}/-/settings/ci_cd has in field "CI/CD
+# configuration file" filename "debian/salsa-ci.yml"


### PR DESCRIPTION
This will help ensure easily machine detectable regressions don't slip into the code base.

This also makes any future contribution process faster and more reliable, as any contributor submitting a Merge Request will get immediate feedback, and the maintainers save time by not having to point out basic mistakes.

Package krb5 build passes on all but three jobs out-of-the-box. The crossbuild-arm64 is allowed to fail by default in Salsa-CI. Additionally allow reprotest and BLHC to fail initially until they are fixed for this package.